### PR TITLE
Set thread limits for parallel execution

### DIFF
--- a/pcntoolkit/util/runner.py
+++ b/pcntoolkit/util/runner.py
@@ -789,6 +789,11 @@ class Runner:
 source activate {self.environment}
 # Force Python to use unbuffered output
 export PYTHONUNBUFFERED=1
+# Ensure that it does not spawn multiple threads randomly.
+export OMP_NUM_THREADS=self.n_cores
+export MKL_NUM_THREADS=self.n_cores
+export OPENBLAS_NUM_THREADS=self.n_cores
+export NUMEXPR_NUM_THREADS=self.n_cores
 # Force stdout/stderr to be unbuffered
 exec 1> >(tee -a {out_file})
 exec 2> >(tee -a {err_file})
@@ -832,6 +837,11 @@ exit $exit_code
 source activate {self.environment}
 # Force Python to use unbuffered output
 export PYTHONUNBUFFERED=1
+# Ensure that it does not spawn multiple threads randomly.
+export OMP_NUM_THREADS=self.n_cores
+export MKL_NUM_THREADS=self.n_cores
+export OPENBLAS_NUM_THREADS=self.n_cores
+export NUMEXPR_NUM_THREADS=self.n_cores
 # Force stdout/stderr to be unbuffered
 exec 1> >(tee -a {out_file})
 exec 2> >(tee -a {err_file})


### PR DESCRIPTION
I received an email from our SLURM administrator indicating that the toolbox spawns multiple threads, thereby overloading the entire node regardless of the number of CPUs requested. This happens because SLURM allocates CPU resources but does not control thread creation in Python. To address this, I added environment variables that force backend functions to use only the number of threads equal to "self.n_cores".