### PR TITLE
Fix NormData netcdf implementation #345

### DIFF
--- a/test/test_dataio/test_normdata.py
+++ b/test/test_dataio/test_normdata.py
@@ -1,4 +1,6 @@
 import copy
+import os
+from tempfile import gettempdir
 
 import numpy as np
 import pytest
@@ -168,3 +170,16 @@ def test_to_dataframe():
 
     print(df)
     print(data.to_dataframe())
+
+
+def test_netcdf(norm_data_from_arrays: NormData):
+    norm_data_from_arrays.to_netcdf(os.path.join(gettempdir(), "test.nc"))
+    norm_data_from_netcdf = NormData.from_netcdf("from_arrays", os.path.join(gettempdir(), "test.nc"))
+
+    # Check if the two norm data objects are equal
+    # Checks for data variables and coordinates.
+    assert norm_data_from_arrays.equals(norm_data_from_netcdf)
+
+    # Check if the two norm data objects are identical
+    # Additionally checks for object's name and attributes.
+    assert norm_data_from_arrays.identical(norm_data_from_netcdf)


### PR DESCRIPTION
I have addressed the issues in the previous PR (#345) related to saving the NormData as a netCDF file. Updated things:

1) Instead of removing and re‑introducing the attributes, I now serialize them with `json.dumps`, so they can be easily saved as a `.nc` file.
2) Added a `has_registered_metadata` method that checks whether the batch‑effect‑related attributes already exist and are not empty. If they do, `register_batch_effects` will not re‑register them. This prevents re‑initialization of batch effects, which could otherwise create discrepancies between the train and test sets during loading.
3) Added a test as recommended.