### PR TITLE
fix(warp): add input validation to WarpLog for non-positive values

### DIFF
--- a/pcntoolkit/math_functions/warp.py
+++ b/pcntoolkit/math_functions/warp.py
@@ -215,7 +215,7 @@ class WarpLog(WarpBase):
         Parameters
         ----------
         x : NDArray[np.float64]
-            Input values
+            Input values (must be strictly positive)
         params : Optional[NDArray[np.float64]], optional
             Not used for logarithmic warp, by default None
 
@@ -223,7 +223,19 @@ class WarpLog(WarpBase):
         -------
         NDArray[np.float64]
             log(x)
+
+        Raises
+        ------
+        ValueError
+            If input contains zero or negative values
         """
+        if np.any(x <= 0):
+            raise ValueError(
+                "WarpLog requires all input values to be strictly positive (> 0). "
+                "Your data contains zero or negative values. Consider:\n"
+                "  1. Using WarpBoxCox or WarpSinhArcsinh which handle negative values\n"
+                "  2. Setting outscaler=None if using WarpLog (warp is applied after scaling)"
+            )
         return np.log(x)
 
     def invf(self, y: NDArray[np.float64], param: Optional[NDArray[np.float64]] = None) -> NDArray[np.float64]:


### PR DESCRIPTION
## Summary
Closes #365 
As discussed in issue #365.

Add input validation to `WarpLog.f()` to prevent silent `NaN` failures when input data contains zero or negative values.
Added input validation in `WarpLog.f()` that raises a clear `ValueError` when non-positive values are detected:
```python
if np.any(x <= 0):
    raise ValueError(
        "WarpLog requires all input values to be strictly positive (> 0). "
        "Your data contains zero or negative values. Consider:\n"
        "  1. Using WarpBoxCox or WarpSinhArcsinh which handle negative values\n"
        "  2. Setting outscaler=None if using WarpLog (warp is applied after scaling)"
    )
```
