### PR TITLE
fix: correct harmonize kwarg to harmonize_data in example notebooks

### DIFF
--- a/examples/02_BLR.ipynb
+++ b/examples/02_BLR.ipynb
@@ -1378,7 +1378,7 @@
     "    scatter_data=train,  # Scatter this data along with the centiles\n",
     "    batch_effects={\"site\": [\"Beijing_Zang\", \"AnnArbor_a\"], \"sex\": [\"M\"]},  # Highlight these groups\n",
     "    show_other_data=True,  # scatter data not in those groups as smaller black circles\n",
-    "    harmonize=True,  # harmonize the scatterdata, this means that we 'remove' the batch effects from the data, by simulating what the data would have looked like if all data was from the same batch.\n",
+    "    harmonize_data=True,  # harmonize the scatterdata, this means that we 'remove' the batch effects from the data, by simulating what the data would have looked like if all data was from the same batch.\n",
     "    show_yhat=True,\n",
     ")"
    ]

--- a/examples/03_HBR_Normal.ipynb
+++ b/examples/03_HBR_Normal.ipynb
@@ -2113,7 +2113,7 @@
     "    scatter_data=train,  # Scatter this data along with the centiles\n",
     "    batch_effects={\"site\": [\"Beijing_Zang\", \"AnnArbor_a\"], \"sex\": [\"M\"]},  # Highlight these groups\n",
     "    show_other_data=True,  # scatter data not in those groups as smaller black circles\n",
-    "    harmonize=True,  # harmonize the scatterdata, this means that we 'remove' the batch effects from the data, by simulating what the data would have looked like if all data was from the same batch.\n",
+    "    harmonize_data=True,  # harmonize the scatterdata, this means that we 'remove' the batch effects from the data, by simulating what the data would have looked like if all data was from the same batch.\n",
     ")"
    ]
   },

--- a/examples/04_HBR_SHASH.ipynb
+++ b/examples/04_HBR_SHASH.ipynb
@@ -2128,7 +2128,7 @@
     "    scatter_data=train,  # Scatter this data along with the centiles\n",
     "    batch_effects={\"site\": [\"Beijing_Zang\", \"AnnArbor_a\"], \"sex\": [\"M\"]},  # Highlight these groups\n",
     "    show_other_data=True,  # scatter data not in those groups as smaller black circles\n",
-    "    harmonize=True,  # harmonize the scatterdata, this means that we 'remove' the batch effects from the data, by simulating what the data would have looked like if all data was from the same batch.\n",
+    "    harmonize_data=True,  # harmonize the scatterdata, this means that we 'remove' the batch effects from the data, by simulating what the data would have looked like if all data was from the same batch.\n",
     "    conditionals=[30]\n",
     ")"
    ]

--- a/examples/05_HBR_Beta.ipynb
+++ b/examples/05_HBR_Beta.ipynb
@@ -2102,7 +2102,7 @@
     "    scatter_data=train,  # Scatter this data along with the centiles\n",
     "    batch_effects={\"site\": [\"Beijing_Zang\", \"AnnArbor_a\"], \"sex\": [\"M\"]},  # Highlight these groups\n",
     "    show_other_data=True,  # scatter data not in those groups as smaller black circles\n",
-    "    harmonize=True,  # harmonize the scatterdata, this means that we 'remove' the batch effects from the data, by simulating what the data would have looked like if all data was from the same batch.\n",
+    "    harmonize_data=True,  # harmonize the scatterdata, this means that we 'remove' the batch effects from the data, by simulating what the data would have looked like if all data was from the same batch.\n",
     ")"
    ]
   },


### PR DESCRIPTION
## Fix: correct [harmonize](cci:1://file:///home/endymion/gsoc/PCNtoolkit/pcntoolkit/normative_model.py:349:4-408:19) kwarg to `harmonize_data` in example notebooks

The problem is discussed in Issue #369

Closes #369

### Changes
Replaced `harmonize=True` with `harmonize_data=True` in:
- [examples/02_BLR.ipynb](cci:7://file:///home/endymion/gsoc/PCNtoolkit/examples/02_BLR.ipynb:0:0-0:0)
- [examples/03_HBR_Normal.ipynb](cci:7://file:///home/endymion/gsoc/PCNtoolkit/examples/03_HBR_Normal.ipynb:0:0-0:0)
- [examples/04_HBR_SHASH.ipynb](cci:7://file:///home/endymion/gsoc/PCNtoolkit/examples/04_HBR_SHASH.ipynb:0:0-0:0)
- [examples/05_HBR_Beta.ipynb](cci:7://file:///home/endymion/gsoc/PCNtoolkit/examples/05_HBR_Beta.ipynb:0:0-0:0)

### Verification
After the fix, setting `harmonize_data=False` produces visibly different centile plots compared to `harmonize_data=True`, confirming the parameter is now correctly passed through.