### PR TITLE
fix - import os and sys to set environment PATH for testing

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 from pathlib import Path
 
@@ -7,6 +6,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+import os
+import sys
+os.environ["PATH"] = os.path.dirname(sys.executable) + os.pathsep + os.environ.get("PATH", "")
 
 @pytest.fixture(autouse=True, scope="session")
 def configure_matplotlib():


### PR DESCRIPTION
Allows to run tests in a remote HPC when using an apptainer