### PR TITLE
fix - return mean and second moment in m1m2()

### DIFF
--- a/pcntoolkit/math_functions/likelihood.py
+++ b/pcntoolkit/math_functions/likelihood.py
@@ -343,7 +343,7 @@ class SHASHbLikelihood(Likelihood):
         Y = kwargs.get("Y", None)
         m1, m2 = m1m2(epsilon, delta)
         true_mu = m1
-        true_sigma = np.sqrt((m2 - true_mu**2))
+        true_sigma = np.sqrt(m2 - true_mu**2)
         SHASH_centered = (Y - mu) / sigma
         SHASH_uncentered = SHASH_centered * true_sigma + true_mu
         Z = S(SHASH_uncentered, epsilon, delta)
@@ -354,7 +354,7 @@ class SHASHbLikelihood(Likelihood):
         Z = kwargs.get("Z", None)
         m1, m2 = m1m2(epsilon, delta)
         true_mu = m1
-        true_sigma = np.sqrt((m2 - true_mu**2))
+        true_sigma = np.sqrt(m2 - true_mu**2)
         SHASH_uncentered = S_inv(Z, epsilon, delta)
         SHASH_centered = (SHASH_uncentered - true_mu) / true_sigma
         Y = SHASH_centered * sigma + mu

--- a/pcntoolkit/math_functions/shash.py
+++ b/pcntoolkit/math_functions/shash.py
@@ -351,23 +351,6 @@ class SHASHbRV(RandomVariable):
     ) -> NDArray[np.float64]:
         s = rng.normal(size=size)
 
-        def P(q: float) -> float:
-            K1 = spp.kv((q + 1) / 2, 0.25)
-            K2 = spp.kv((q - 1) / 2, 0.25)
-            a = (K1 + K2) * CONST1
-            return a
-
-        def m1m2(epsilon: float, delta: float) -> Tuple[float, float]:
-            inv_delta = 1.0 / delta
-            two_inv_delta = 2.0 * inv_delta
-            p1 = P(inv_delta)
-            p2 = P(two_inv_delta)
-            eps_delta = epsilon / delta
-            sinh_eps_delta = np.sinh(eps_delta)
-            cosh_2eps_delta = np.cosh(2 * eps_delta)
-            mean = sinh_eps_delta * p1
-            raw_second = (cosh_2eps_delta * p2 - 1) / 2
-            return mean, raw_second
 
         mean, raw_second = m1m2(epsilon, delta)
         out = ((np.sinh((np.arcsinh(s) + epsilon) / delta) - mean) / np.sqrt(raw_second - mean**2)) * sigma + mu  # type: ignore

--- a/pcntoolkit/math_functions/shash.py
+++ b/pcntoolkit/math_functions/shash.py
@@ -111,8 +111,7 @@ def m1m2(epsilon: float, delta: float) -> Tuple[float, float]:
     cosh_2eps_delta = np.cosh(2 * eps_delta)
     mean = sinh_eps_delta * p1
     raw_second = (cosh_2eps_delta * p2 - 1) / 2
-    var = raw_second - mean**2
-    return mean, var
+    return mean, raw_second
 
 class Kv(BinaryScalarOp):
     nfunc_spec = ("scipy.special.kv", 2, 1)
@@ -201,8 +200,7 @@ class SHASH(Continuous):
         cosh_2eps_delta = np.cosh(2 * eps_delta)
         mean = sinh_eps_delta * p1
         raw_second = (cosh_2eps_delta * p2 - 1) / 2
-        var = raw_second - mean**2
-        return mean, var
+        return mean, raw_second
 
     @classmethod
     def dist(cls, epsilon: pt.TensorLike, delta: pt.TensorLike, **kwargs: Any) -> Any:
@@ -369,11 +367,10 @@ class SHASHbRV(RandomVariable):
             cosh_2eps_delta = np.cosh(2 * eps_delta)
             mean = sinh_eps_delta * p1
             raw_second = (cosh_2eps_delta * p2 - 1) / 2
-            var = raw_second - mean**2
-            return mean, var
+            return mean, raw_second
 
-        mean, var = m1m2(epsilon, delta)
-        out = ((np.sinh((np.arcsinh(s) + epsilon) / delta) - mean) / np.sqrt(var)) * sigma + mu  # type: ignore
+        mean, raw_second = m1m2(epsilon, delta)
+        out = ((np.sinh((np.arcsinh(s) + epsilon) / delta) - mean) / np.sqrt(raw_second - mean**2)) * sigma + mu  # type: ignore
         return out
 
 
@@ -405,7 +402,8 @@ class SHASHb(Continuous):
         epsilon: float,
         delta: float,  # type: ignore
     ) -> float:
-        mean, var = SHASH.m1m2(epsilon, delta)
+        mean, raw_second = SHASH.m1m2(epsilon, delta)
+        var = raw_second - mean**2
         remapped_value = ((value - mu) / sigma) * np.sqrt(var) + mean  # type: ignore
         this_S = S(remapped_value, epsilon, delta)
         this_S_sqr = np.square(this_S)


### PR DESCRIPTION
#### Reference issue (if any)

Closes #461


#### What does this implement/fix?

in HBR SHASH the m1m2() function was not returning the second moment but the variance. However in other spots in the code the second moment was expected as the output of the function. 
