### PR TITLE
Fix z scores saved file during cluster jobs

### DIFF
--- a/pcntoolkit/dataio/norm_data.py
+++ b/pcntoolkit/dataio/norm_data.py
@@ -1162,8 +1162,7 @@ class NormData(xr.Dataset):
         res_path = os.path.join(save_dir, f"Z_{self.name}.csv")
         lock_path = res_path + ".lock"
         with FileLock(lock_path):
-            # Read old content by path inside the lock — no other
-            # job can modify the file between the read and write.
+            # Read old content first
             old_results = pd.read_csv(res_path) if os.path.exists(res_path) and os.path.getsize(res_path) > 0 else None
             if old_results is not None:
                 old_results["observations"] = old_results["observations"].astype(str)
@@ -1185,9 +1184,7 @@ class NormData(xr.Dataset):
                     key=lambda idx: pd.to_numeric(idx, errors="coerce")
                 )
                 new_results.index = new_results.index.astype(str)
-            # Open with mode="w": creates or truncates, then writes
-            # once at position 0.  No seek+truncate sequence needed —
-            # simpler and safe on NFS.
+            # Write new content
             with open(res_path, mode="w", encoding="utf-8") as f:
                 new_results.to_csv(f)
 
@@ -1218,8 +1215,7 @@ class NormData(xr.Dataset):
         res_path = os.path.join(save_dir, f"centiles_{self.name}.csv")
         lock_path = res_path + ".lock"
         with FileLock(lock_path):
-            # Read old content by path inside the lock — no other
-            # job can modify the file between the read and write.
+            # Read old content first
             old_results = pd.read_csv(res_path) if os.path.exists(res_path) and os.path.getsize(res_path) > 0 else None
             if old_results is not None:
                 old_results["observations"] = old_results["observations"].astype(str)
@@ -1241,9 +1237,7 @@ class NormData(xr.Dataset):
                     key=lambda idx: pd.to_numeric(idx, errors="coerce")
                 )
                 # new_results.index = new_results.index.astype(str)
-            # Open with mode="w": creates or truncates, then writes
-            # once at position 0.  No seek+truncate sequence needed —
-            # simpler and safe on NFS.
+            # Write new content
             with open(res_path, mode="w", encoding="utf-8") as f:
                 new_results.to_csv(f)
 
@@ -1277,8 +1271,7 @@ class NormData(xr.Dataset):
         res_path = os.path.join(save_dir, f"logp_{self.name}.csv")
         lock_path = res_path + ".lock"
         with FileLock(lock_path):
-            # Read old content by path inside the lock — no other
-            # job can modify the file between the read and write.
+            # Read old content first
             old_results = pd.read_csv(res_path) if os.path.exists(res_path) and os.path.getsize(res_path) > 0 else None
             if old_results is not None:
                 old_results["observations"] = old_results["observations"].astype(str)
@@ -1300,9 +1293,7 @@ class NormData(xr.Dataset):
                     key=lambda idx: pd.to_numeric(idx, errors="coerce")
                 )
                 new_results.index = new_results.index.astype(str)
-            # Open with mode="w": creates or truncates, then writes
-            # once at position 0.  No seek+truncate sequence needed —
-            # simpler and safe on NFS.
+            # Write new content
             with open(res_path, mode="w", encoding="utf-8") as f:
                 new_results.to_csv(f)
 
@@ -1323,8 +1314,7 @@ class NormData(xr.Dataset):
         res_path = os.path.join(save_dir, f"statistics_{self.name}.csv")
         lock_path = res_path + ".lock"
         with FileLock(lock_path):
-            # Read old content by path inside the lock — no other
-            # job can modify the file between the read and write.
+            # Read old content first
             old_results = pd.read_csv(res_path, index_col=0) if os.path.exists(res_path) and os.path.getsize(res_path) > 0 else None
             if old_results is not None:
                 # Merge on statistic, keeping right (new) values for overlapping columns
@@ -1333,9 +1323,7 @@ class NormData(xr.Dataset):
                 new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
             else:
                 new_results = mdf
-            # Open with mode="w": creates or truncates, then writes
-            # once at position 0.  No seek+truncate sequence needed —
-            # simpler and safe on NFS.
+            # Write new content
             with open(res_path, mode="w", encoding="utf-8") as f:
                 new_results.to_csv(f)
 

--- a/pcntoolkit/dataio/norm_data.py
+++ b/pcntoolkit/dataio/norm_data.py
@@ -1162,31 +1162,33 @@ class NormData(xr.Dataset):
         res_path = os.path.join(save_dir, f"Z_{self.name}.csv")
         lock_path = res_path + ".lock"
         with FileLock(lock_path):
-            with open(res_path, mode="r+" if os.path.exists(res_path) else "w", encoding="utf-8") as f:
-                f.seek(0)
-                old_results = pd.read_csv(f) if os.path.getsize(res_path) > 0 else None
-                if old_results is not None:
-                    old_results["observations"] = old_results["observations"].astype(str)
-                    old_results.set_index(["observations"], inplace=True)
-                    # Merge on observations, keeping right (new) values for overlapping columns
-                    new_results = old_results.merge(zdf, on="observations", how="outer", suffixes=("_old", ""))
-                    # Drop columns ending with '_old' as they're the duplicates from old_results
-                    new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
-                else:
-                    new_results = zdf
-                f.seek(0)
-                f.truncate()
-                if "observations" in new_results.columns:
-                    new_results = new_results.sort_values(
-                        by="observations",
-                        key=lambda col: pd.to_numeric(col, errors="coerce"),
-                    )
-                    new_results["observations"] = new_results["observations"].astype(str)
-                else:
-                    new_results = new_results.sort_index(
-                        key=lambda idx: pd.to_numeric(idx, errors="coerce")
-                    )
-                    new_results.index = new_results.index.astype(str)
+            # Read old content by path inside the lock — no other
+            # job can modify the file between the read and write.
+            old_results = pd.read_csv(res_path) if os.path.exists(res_path) and os.path.getsize(res_path) > 0 else None
+            if old_results is not None:
+                old_results["observations"] = old_results["observations"].astype(str)
+                old_results.set_index(["observations"], inplace=True)
+                # Merge on observations, keeping right (new) values for overlapping columns
+                new_results = old_results.merge(zdf, on="observations", how="outer", suffixes=("_old", ""))
+                # Drop columns ending with '_old' as they're the duplicates from old_results
+                new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
+            else:
+                new_results = zdf
+            if "observations" in new_results.columns:
+                new_results = new_results.sort_values(
+                    by="observations",
+                    key=lambda col: pd.to_numeric(col, errors="coerce"),
+                )
+                new_results["observations"] = new_results["observations"].astype(str)
+            else:
+                new_results = new_results.sort_index(
+                    key=lambda idx: pd.to_numeric(idx, errors="coerce")
+                )
+                new_results.index = new_results.index.astype(str)
+            # Open with mode="w": creates or truncates, then writes
+            # once at position 0.  No seek+truncate sequence needed —
+            # simpler and safe on NFS.
+            with open(res_path, mode="w", encoding="utf-8") as f:
                 new_results.to_csv(f)
 
     def load_zscores(self, save_dir) -> None:
@@ -1216,31 +1218,33 @@ class NormData(xr.Dataset):
         res_path = os.path.join(save_dir, f"centiles_{self.name}.csv")
         lock_path = res_path + ".lock"
         with FileLock(lock_path):
-            with open(res_path, mode="r+" if os.path.exists(res_path) else "w", encoding="utf-8") as f:
-                f.seek(0)
-                old_results = pd.read_csv(f) if os.path.getsize(res_path) > 0 else None
-                if old_results is not None:
-                    old_results["observations"] = old_results["observations"].astype(str)
-                    old_results.set_index(["observations", "centile"], inplace=True)
-                    # Merge on observations, keeping right (new) values for overlapping columns
-                    new_results = old_results.merge(centiles, on=["observations", "centile"], how="outer", suffixes=("_old", ""))
-                    # Drop columns ending with '_old' as they're the duplicates from old_results
-                    new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
-                else:
-                    new_results = centiles
-                f.seek(0)
-                f.truncate()
-                if "observations" in new_results.columns:
-                    new_results = new_results.sort_values(
-                        by="observations",
-                        key=lambda col: pd.to_numeric(col, errors="coerce"),
-                    )
-                    new_results["observations"] = new_results["observations"].astype(str)
-                else:
-                    new_results = new_results.sort_index(
-                        key=lambda idx: pd.to_numeric(idx, errors="coerce")
-                    )
-                    # new_results.index = new_results.index.astype(str)
+            # Read old content by path inside the lock — no other
+            # job can modify the file between the read and write.
+            old_results = pd.read_csv(res_path) if os.path.exists(res_path) and os.path.getsize(res_path) > 0 else None
+            if old_results is not None:
+                old_results["observations"] = old_results["observations"].astype(str)
+                old_results.set_index(["observations", "centile"], inplace=True)
+                # Merge on observations, keeping right (new) values for overlapping columns
+                new_results = old_results.merge(centiles, on=["observations", "centile"], how="outer", suffixes=("_old", ""))
+                # Drop columns ending with '_old' as they're the duplicates from old_results
+                new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
+            else:
+                new_results = centiles
+            if "observations" in new_results.columns:
+                new_results = new_results.sort_values(
+                    by="observations",
+                    key=lambda col: pd.to_numeric(col, errors="coerce"),
+                )
+                new_results["observations"] = new_results["observations"].astype(str)
+            else:
+                new_results = new_results.sort_index(
+                    key=lambda idx: pd.to_numeric(idx, errors="coerce")
+                )
+                # new_results.index = new_results.index.astype(str)
+            # Open with mode="w": creates or truncates, then writes
+            # once at position 0.  No seek+truncate sequence needed —
+            # simpler and safe on NFS.
+            with open(res_path, mode="w", encoding="utf-8") as f:
                 new_results.to_csv(f)
 
     def load_centiles(self, save_dir) -> None:
@@ -1273,31 +1277,33 @@ class NormData(xr.Dataset):
         res_path = os.path.join(save_dir, f"logp_{self.name}.csv")
         lock_path = res_path + ".lock"
         with FileLock(lock_path):
-            with open(res_path, mode="r+" if os.path.exists(res_path) else "w", encoding="utf-8") as f:
-                f.seek(0)
-                old_results = pd.read_csv(f) if os.path.getsize(res_path) > 0 else None
-                if old_results is not None:
-                    old_results["observations"] = old_results["observations"].astype(str)
-                    old_results.set_index(["observations"], inplace=True)
-                    # Merge on observations, keeping right (new) values for overlapping columns
-                    new_results = old_results.merge(logp, on="observations", how="outer", suffixes=("_old", ""))
-                    # Drop columns ending with '_old' as they're the duplicates from old_results
-                    new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
-                else:
-                    new_results = logp
-                f.seek(0)
-                f.truncate()
-                if "observations" in new_results.columns:
-                    new_results = new_results.sort_values(
-                        by="observations",
-                        key=lambda col: pd.to_numeric(col, errors="coerce"),
-                    )
-                    new_results["observations"] = new_results["observations"].astype(str)
-                else:
-                    new_results = new_results.sort_index(
-                        key=lambda idx: pd.to_numeric(idx, errors="coerce")
-                    )
-                    new_results.index = new_results.index.astype(str)
+            # Read old content by path inside the lock — no other
+            # job can modify the file between the read and write.
+            old_results = pd.read_csv(res_path) if os.path.exists(res_path) and os.path.getsize(res_path) > 0 else None
+            if old_results is not None:
+                old_results["observations"] = old_results["observations"].astype(str)
+                old_results.set_index(["observations"], inplace=True)
+                # Merge on observations, keeping right (new) values for overlapping columns
+                new_results = old_results.merge(logp, on="observations", how="outer", suffixes=("_old", ""))
+                # Drop columns ending with '_old' as they're the duplicates from old_results
+                new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
+            else:
+                new_results = logp
+            if "observations" in new_results.columns:
+                new_results = new_results.sort_values(
+                    by="observations",
+                    key=lambda col: pd.to_numeric(col, errors="coerce"),
+                )
+                new_results["observations"] = new_results["observations"].astype(str)
+            else:
+                new_results = new_results.sort_index(
+                    key=lambda idx: pd.to_numeric(idx, errors="coerce")
+                )
+                new_results.index = new_results.index.astype(str)
+            # Open with mode="w": creates or truncates, then writes
+            # once at position 0.  No seek+truncate sequence needed —
+            # simpler and safe on NFS.
+            with open(res_path, mode="w", encoding="utf-8") as f:
                 new_results.to_csv(f)
 
     def load_logp(self, save_dir) -> None:
@@ -1317,18 +1323,20 @@ class NormData(xr.Dataset):
         res_path = os.path.join(save_dir, f"statistics_{self.name}.csv")
         lock_path = res_path + ".lock"
         with FileLock(lock_path):
-            with open(res_path, mode="r+" if os.path.exists(res_path) else "w", encoding="utf-8") as f:
-                f.seek(0)
-                old_results = pd.read_csv(f, index_col=0) if os.path.getsize(res_path) > 0 else None
-                if old_results is not None:
-                    # Merge on observations, keeping right (new) values for overlapping columns
-                    new_results = old_results.merge(mdf, on="statistic", how="outer", suffixes=("_old", ""))
-                    # Drop columns ending with '_old' as they're the duplicates from old_results
-                    new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
-                else:
-                    new_results = mdf
-                f.seek(0)
-                f.truncate()
+            # Read old content by path inside the lock — no other
+            # job can modify the file between the read and write.
+            old_results = pd.read_csv(res_path, index_col=0) if os.path.exists(res_path) and os.path.getsize(res_path) > 0 else None
+            if old_results is not None:
+                # Merge on statistic, keeping right (new) values for overlapping columns
+                new_results = old_results.merge(mdf, on="statistic", how="outer", suffixes=("_old", ""))
+                # Drop columns ending with '_old' as they're the duplicates from old_results
+                new_results = new_results.loc[:, ~new_results.columns.str.endswith("_old")]
+            else:
+                new_results = mdf
+            # Open with mode="w": creates or truncates, then writes
+            # once at position 0.  No seek+truncate sequence needed —
+            # simpler and safe on NFS.
+            with open(res_path, mode="w", encoding="utf-8") as f:
                 new_results.to_csv(f)
 
     def load_statistics(self, save_dir) -> None:


### PR DESCRIPTION
On cluster filesystems, erasing a file doesn't happen instantly - the disk still sees the old content for a moment. If a job writes during that moment, the new content gets added after the old content instead of replacing it. This can corrupt the CSV files, producing duplicate headers when multiple jobs wrote to the same file.

**Fix**: 
Instead of opening the file, erasing it, and writing, we now:

- Read the old file into Python
- Combine the old and new results in Python's memory
- Write the final combined result to a brand new clean file

Everything is combined in memory before anything touches the file, so there's no moment where the file is half-erased or half-written.
