### PR TITLE
doc: fix invalid import in quickstart example

### DIFF
--- a/doc/getting_started/quickstart.rst
+++ b/doc/getting_started/quickstart.rst
@@ -15,9 +15,9 @@ Example usage
 
 .. code-block:: python
 
-    from pcntoolkit import {load_fcon, BLR, NormativeModel}
+    from pcntoolkit import load_fcon1000, BLR, NormativeModel
 
-    fcon1000 = load_fcon()
+    fcon1000 = load_fcon1000()
 
     train, test = fcon1000.train_test_split()
 
@@ -27,4 +27,3 @@ Example usage
                         outscaler='standardize')
 
     model.fit_predict(train, test)
-


### PR DESCRIPTION
## Summary
- Quickstart example used invalid `{}` import syntax (SyntaxError)
- Also referenced a nonexistent `load_fcon` (actual name: `load_fcon1000`)

Fixes #507

## AI usage
Bug found and fix drafted with AI assistance (Claude Code / Claude Sonnet 5); verified manually against the current dev branch source and GitHub raw content before submitting.

## Test plan
- [ ] Built docs locally with `make livehtml` and confirmed the code block renders and is copy-paste runnable