### PR TITLE
doc: fix invalid import in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ pip install pcntoolkit
 ## Example usage
 
 ```python
-from pcntoolkit import {load_fcon, BLR, NormativeModel}
+from pcntoolkit import load_fcon1000, BLR, NormativeModel
 
-fcon1000 = load_fcon()
+fcon1000 = load_fcon1000()
 
 train, test = fcon1000.train_test_split()
 


### PR DESCRIPTION
README.md had the same invalid {} import syntax and nonexistent
load_fcon reference already fixed in quickstart.rst by #509, but
that PR didn't cover this file.
Related to [#507](https://github.com/predictive-clinical-neuroscience/PCNtoolkit/issues/507)
Fixes #511 

AI usage
Bug found and fix drafted with AI assistance (Claude Code / Claude Sonnet 5); verified against the current dev branch README.md before submitting.